### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -23,6 +23,8 @@ concurrency:
 
 jobs:
   lint:
+    permissions:
+      contents: read
     name: ESLint
     runs-on: ubuntu-latest
     timeout-minutes: 10


### PR DESCRIPTION
Potential fix for [https://github.com/0bvim/ft_transcendence-ms-auth/security/code-scanning/1](https://github.com/0bvim/ft_transcendence-ms-auth/security/code-scanning/1)

To fix the issue, we will add a `permissions` block to the `lint` job to explicitly define the minimal permissions required. Based on the workflow's operations, the `contents: read` permission is sufficient for most steps, as they involve checking out the code and running linting tools. Additionally, the `actions/upload-artifact` and `reviewdog/action-eslint` steps may require specific permissions, such as `contents: write` or `pull-requests: write`. However, we will start with `contents: read` and adjust if necessary.

The `permissions` block will be added under the `lint` job definition.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
